### PR TITLE
Intro improvement

### DIFF
--- a/addons/fire_droid_core/plugin.gd
+++ b/addons/fire_droid_core/plugin.gd
@@ -35,7 +35,6 @@ func _update_custom_settings() -> void:
 			"hint_string": (
 				str(TYPE_STRING) + "/" + str(PROPERTY_HINT_FILE) + ":*.tscn"
 			),
-			#"hint_string": "*.tscn",
 			"initial_value": [
 				"res://addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn",
 				"res://addons/fire_droid_core/scenes/logo_intro/fire_droid_logo_intro.tscn"

--- a/addons/fire_droid_core/plugin.gd
+++ b/addons/fire_droid_core/plugin.gd
@@ -15,7 +15,7 @@ func _exit_tree() -> void:
 
 func _update_custom_settings() -> void:
 	# Format -> "setting_name": "default_value"
-	const custom_settings: Array[Dictionary] = [
+	var custom_settings: Array[Dictionary] = [
 		{
 			"name": "fd_core/project_manager",
 			"type": TYPE_STRING,
@@ -27,6 +27,19 @@ func _update_custom_settings() -> void:
 			"name": "fd_core/enable_debug_mode",
 			"type": TYPE_BOOL,
 			"initial_value": false,
+		},
+		{
+			"name": "fd_core/intro_paths",
+			"type": TYPE_ARRAY,
+			"hint": PROPERTY_HINT_TYPE_STRING,
+			"hint_string": (
+				str(TYPE_STRING) + "/" + str(PROPERTY_HINT_FILE) + ":*.tscn"
+			),
+			#"hint_string": "*.tscn",
+			"initial_value": [
+				"res://addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn",
+				"res://addons/fire_droid_core/scenes/logo_intro/fire_droid_logo_intro.tscn"
+			],
 		}
 	]
 	for setting in custom_settings:

--- a/addons/fire_droid_core/scenes/fd_core.gd
+++ b/addons/fire_droid_core/scenes/fd_core.gd
@@ -57,8 +57,6 @@ enum ErrorCodes {
 	DEFAULT_ERROR, ## Default error for general purposes.
 }
 
-const _GodotLogoIntroScene = preload("res://addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn")
-const _FireDroidLogoIntroScene = preload("res://addons/fire_droid_core/scenes/logo_intro/fire_droid_logo_intro.tscn")
 const _TransitionScene = preload("res://addons/fire_droid_core/scenes/transitions/transition.tscn")
 
 ## Default values for every transition. Some functions allows overriding these values.[br][br]
@@ -135,11 +133,17 @@ func _ready() -> void:
 		StringName(ProjectSettings.get_setting("fd_core/project_manager", ""))
 	)
 
-	await change_scene_to(_GodotLogoIntroScene.instantiate(), {"duration_out": 0.8})
-	await _current_scene.finished
-
-	await change_scene_to(_FireDroidLogoIntroScene.instantiate())
-	await _current_scene.finished
+	const DEFAULT_INTRO_PATHS: Array[String] = [
+		"res://addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn",
+		"res://addons/fire_droid_core/scenes/logo_intro/fire_droid_logo_intro.tscn"
+	]
+	var intro_paths: Array[String] = (
+		ProjectSettings.get_setting("fd_core/intro_paths", DEFAULT_INTRO_PATHS)
+	)
+	for intro_path: String in intro_paths:
+		var intro: Control = load(intro_path).instantiate()
+		await change_scene_to(intro, intro.transition_override_properties)
+		await _current_scene.finished
 
 	await change_scene_to(_project_manager.initial_scene.instantiate())
 

--- a/addons/fire_droid_core/scenes/fd_core.gd
+++ b/addons/fire_droid_core/scenes/fd_core.gd
@@ -133,11 +133,11 @@ func _ready() -> void:
 		StringName(ProjectSettings.get_setting("fd_core/project_manager", ""))
 	)
 
-	const DEFAULT_INTRO_PATHS: Array[String] = [
+	const DEFAULT_INTRO_PATHS: PackedStringArray = [
 		"res://addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn",
 		"res://addons/fire_droid_core/scenes/logo_intro/fire_droid_logo_intro.tscn"
 	]
-	var intro_paths: Array[String] = (
+	var intro_paths: PackedStringArray = (
 		ProjectSettings.get_setting("fd_core/intro_paths", DEFAULT_INTRO_PATHS)
 	)
 	for intro_path: String in intro_paths:

--- a/addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn
+++ b/addons/fire_droid_core/scenes/logo_intro/godot_logo_intro.tscn
@@ -1489,6 +1489,9 @@ _data = {
 
 [node name="GodotLogoIntro" instance=ExtResource("1_fk86y")]
 background_color = Color(0.227451, 0.254902, 0.345098, 1)
+transition_override_properties = {
+"duration_out": 0.8
+}
 frames = SubResource("SpriteFrames_mlvdw")
 audio_stream_delay = 1.5
 

--- a/addons/fire_droid_core/scenes/logo_intro/logo_intro.gd
+++ b/addons/fire_droid_core/scenes/logo_intro/logo_intro.gd
@@ -13,6 +13,9 @@ signal finished
 @export var background_color: Color = Color.DIM_GRAY: ## Color of static background.
 	set = _set_background_color
 
+@export_group("Transition Overrides")
+@export var transition_override_properties: Dictionary = {}
+
 @export_group("Frames Options")
 @export var frames: SpriteFrames: set = _set_frames ## Desired frames to be in the animation.
 @export var auto_update_animation_frames: bool = false  ## Used only when editing logo intro
@@ -23,7 +26,7 @@ signal finished
 @export_group("Skip Options")
 @export var can_be_skipped: bool = true
 @export_range(0.0, 5.0, 0.1, "or_greater") var skip_lock_delay: float = 1.5
-@export var skip_key: Key = KEY_ESCAPE
+@export var skip_action: StringName = &"ui_cancel"
 
 @export_group("Audio Options")
 @export var audio_stream: AudioStream = null
@@ -45,6 +48,8 @@ var _has_been_skipped: bool = false
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		#timer_start_animation.timeout.connect(_start_animation)
+		if not skip_action in InputMap.get_actions():
+			FDCore.warning("Invalid skip_action on intro")
 		animation_player.animation_finished.connect(_on_finished)
 		animation_player.set_current_animation("default")
 		animation_player.stop()
@@ -61,8 +66,8 @@ func _physics_process(delta: float) -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventKey:
-		if event.keycode == skip_key and _can_skip:
+	if event.is_action(skip_action) and _can_skip:
+		if event.is_pressed() and not event.is_echo():
 			skip()
 
 


### PR DESCRIPTION
# Relevant changes
- Added list of intro paths to Project Settings (`"fd_core/intro_paths"`);
- Custom intros now can be added / Old default intros can be removed;
- Changed skip key to skip action (instead of using Key enum to check skip, action is used to check);
- Added transition overriders customization for each individual intro.