### PR TITLE
Project manager setup

### DIFF
--- a/addons/fire_droid_core/plugin.gd
+++ b/addons/fire_droid_core/plugin.gd
@@ -47,6 +47,18 @@ func _update_custom_settings() -> void:
 			"hint_string": "*.gd",
 			"initial_value": "",
 		},
+		{
+			"name": "fd_core/initial_scene",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_FILE,
+			"hint_string": "*.tscn",
+			"initial_value": "",
+		},
+		{
+			"name": "fd_core/project_manager_parameters",
+			"type": TYPE_DICTIONARY,
+			"initial_value": {}
+		},
 	]
 	for setting in custom_settings:
 		var setting_name: String = setting.get("name")

--- a/addons/fire_droid_core/scenes/defaults/default_project_manager.gd
+++ b/addons/fire_droid_core/scenes/defaults/default_project_manager.gd
@@ -5,5 +5,9 @@ func _init() -> void:
 	initial_scene = preload("res://addons/fire_droid_core/scenes/defaults/main.tscn")
 
 
+func _setup(params: Dictionary) -> void:
+	pass
+
+
 func _on_action_triggered(action: StringName, context: StringName = &"") -> void:
 	pass

--- a/addons/fire_droid_core/scenes/fd_load.gd
+++ b/addons/fire_droid_core/scenes/fd_load.gd
@@ -263,6 +263,12 @@ func has_loaded(path: String) -> bool:
 	return ResourceLoader.has_cached(path)
 
 
+## Return [code]true[/code] if last loading had any failure.[br]This method is
+## a short way to [code]FDLoad.get_failure_paths().size() > 0[/code].
+func has_failures() -> bool:
+	return _failure_paths.size() > 0
+
+
 ## Return a loaded resource by passing it's [param path]. Optional parameters
 ## can be passed:[br][br]
 ## ▪ [param type_hint] is the target type of the resource, as a [String];[br]

--- a/addons/fire_droid_core/scenes/fd_project_manager.gd
+++ b/addons/fire_droid_core/scenes/fd_project_manager.gd
@@ -5,13 +5,11 @@ extends Node
 ## This class works as a template, and all project managers compatible with FDCore
 ## must inherit from this.[br]There are two mandatory actions for a project
 ## manager creation:[br][br]
-## 1. Set [member initial_scene]: this can be done by assigning a [PackedScene]
-## to [member initial_scene] inside [method Object._init].[br][br][b]Example:[/b]
-## [codeblock]
-## func _init() -> void:
-##     initial_scene = preload("res://scenes/main_screen.tscn")
-## [/codeblock]
-## 2. Override [method _on_action_triggered]: this method is the main handler for
+## 1. Set [member initial_scene]: this can be done by picking up the desired
+## scene location at [code]ProjectSettings->FDCore->Initial Scene[/code];[br]
+## 2. Implement [method _setup]: [b]Do not override the [method _ready]
+## method![/b] Instead implement all initializations inside [method _setup];[br]
+## 3. Override [method _on_action_triggered]: this method is the main handler for
 ## all triggered actions coming from FDCore. Override this to define interactions
 ## over the project.[br][br][b]Example:[/b]
 ## [codeblock]
@@ -34,18 +32,14 @@ extends Node
 
 
 ## This is the first scene that will be loaded after the logo intros animations.
-## If this is [code]null[/code] at begin of execution, the program will be
-## terminated with exit code 1. To prevent it, set the property value inside the
-## built-in method [method _init].[br][br][b]Example:[/b]
-## [codeblock]
-## func _init():
-##     initial_scene = preload("res://scenes/main_screen.tscn")
-## [/codeblock]
-
+## The scene is loaded at the initialization of [FDProjectManager], inside [FDCore].
+## [br]The path of initial scene must be set in
+## [code]ProjectSettings->FDCore->Initial Scene[/code].
 var initial_scene: PackedScene = null
 
 
 func _ready() -> void:
+	_setup(ProjectSettings.get_setting("fd_core/project_manager_parameters", {}))
 	pass
 
 
@@ -80,6 +74,16 @@ func start_loading_with_screen(
 	await FDCore.change_scene_to(loading_screen)
 	FDLoad.start()
 	await loading_screen.finished
+
+
+## This is an overridable method.[br][br]
+## Use this method to setup project manager instead of using [method _ready]
+## (overriding default FDProjectManager _ready method can cause unexpected
+## behaviours).[br][br][param params] is a [Dictionary] containing custom
+## parameters defined previously in Project Settings. To modify the dictionary,
+## change the value of setting [code]"fd_core/project_manager_parameters"[/code].
+func _setup(params: Dictionary) -> void:
+	pass
 
 
 ## This is an overridable method.[br][br]


### PR DESCRIPTION
# Relevant changes
- Moved `initial_scene` setup from _init in FDProjectManager to Project Settings (it is now a settings in the FDCore tab);
- Added a custom `_setup` method to FDProjectManager, that passes parameters defined in the new project setting  `project_manager_parameters`;
- Refactored initialization and initial loading in FDCore `_ready`. Now it is in a separated function;
- Added a method to FDLoad, to check if last loading had failures.